### PR TITLE
Meta+Ports: Make 'package.sh showproperty' report multiple properties

### DIFF
--- a/Meta/lint-ports.py
+++ b/Meta/lint-ports.py
@@ -197,16 +197,17 @@ def get_port_properties(port):
     """
 
     props = {}
-    for prop in PORT_PROPERTIES:
-        res = subprocess.run(f"cd {port}; exec ./package.sh showproperty {prop}", shell=True, capture_output=True)
-        if res.returncode == 0:
-            props[prop] = res.stdout.decode('utf-8').strip()
-        else:
-            print((
-                f'Executing "./package.sh showproperty {prop}" script for port {port} failed with '
-                f'exit code {res.returncode}, output from stderr:\n{res.stderr.decode("utf-8").strip()}'
-            ))
-            props[prop] = ''
+    package_sh_command = f"./package.sh showproperty {' '.join(PORT_PROPERTIES)}"
+    res = subprocess.run(f"cd {port}; exec {package_sh_command}", shell=True, capture_output=True)
+    if res.returncode == 0:
+        results = res.stdout.decode('utf-8').split('\n\n')
+        props = {prop:results[i].strip() for i,prop in enumerate(PORT_PROPERTIES)}
+    else:
+        print((
+            f'Executing "{package_sh_command}" script for port {port} failed with '
+            f'exit code {res.returncode}, output from stderr:\n{res.stderr.decode("utf-8").strip()}'
+        ))
+        props = {x:'' for x in PORT_PROPERTIES}
     return props
 
 

--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -543,18 +543,22 @@ do_uninstall() {
     uninstall
 }
 do_showproperty() {
-    if ! declare -p "${1}" > /dev/null 2>&1; then
-        echo "Property '$1' is not set." >&2
-        exit 1
-    fi
-    property_declaration="$(declare -p "${1}")"
-    if [[ "$property_declaration" =~ "declare -a" ]]; then
-        prop_array="${1}[@]"
-        # Some magic to avoid empty arrays being considered unset.
-        echo "${!prop_array+"${!prop_array}"}"
-    else
-        echo ${!1}
-    fi
+    while [ $# -gt 0 ]; do
+        if ! declare -p "${1}" > /dev/null 2>&1; then
+            echo "Property '$1' is not set." >&2
+            exit 1
+        fi
+        property_declaration="$(declare -p "${1}")"
+        if [[ "$property_declaration" =~ "declare -a" ]]; then
+            prop_array="${1}[@]"
+            # Some magic to avoid empty arrays being considered unset.
+            echo "${!prop_array+"${!prop_array}"}"
+        else
+            echo ${!1}
+        fi
+        printf '\n'
+        shift
+    done
 }
 do_all() {
     do_installdepends


### PR DESCRIPTION
And use that to avoid shelling out multiple times for checking
properties in lint-ports.py.